### PR TITLE
Add pygeoapi + MapLibre dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Geospatial Dataset Publishing Dev Environment
+
+This repository contains a minimal Docker Compose setup for running
+[pygeoapi](https://pygeoapi.io/) alongside a simple web client using
+[MapLibre](https://maplibre.org/) and [Chart.js](https://www.chartjs.org/).
+
+## Prerequisites
+- Docker Desktop with Docker Compose v2+
+- (Optional) GDAL >= 3.0 for converting data to other formats
+
+## Usage
+1. Build and start the services:
+   ```bash
+   docker compose up --build
+   ```
+2. Access pygeoapi at [http://localhost:5000](http://localhost:5000)
+3. Access the web client at [http://localhost:8080](http://localhost:8080)
+
+The web client fetches features from pygeoapi and displays them on a
+MapLibre map and Chart.js chart.
+
+## Data
+The sample dataset resides in `data/points.geojson`. You can replace
+this file with your own dataset. Update `pygeoapi/config/pygeoapi-config.yml`
+if you change the path or dataset name.

--- a/data/points.geojson
+++ b/data/points.geojson
@@ -1,0 +1,25 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [102.0, 0.5]
+      },
+      "properties": {
+        "name": "Sample Point 1"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [103.0, 1.0]
+      },
+      "properties": {
+        "name": "Sample Point 2"
+      }
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  pygeoapi:
+    image: geopython/pygeoapi:latest
+    volumes:
+      - ./pygeoapi/config/pygeoapi-config.yml:/pygeoapi/local.config
+      - ./data:/data
+    environment:
+      - PYGEOAPI_CONFIG=/pygeoapi/local.config
+      - PYGEOAPI_OPENAPI=/pygeoapi/openapi.yml
+    ports:
+      - "5000:80"
+
+  web:
+    build: ./web
+    ports:
+      - "8080:80"
+    depends_on:
+      - pygeoapi

--- a/pygeoapi/config/pygeoapi-config.yml
+++ b/pygeoapi/config/pygeoapi-config.yml
@@ -1,0 +1,24 @@
+server:
+  url: http://localhost:5000
+  mimetype: application/json
+  encoding: utf-8
+  language: en
+  cors: true
+
+logging:
+  level: INFO
+
+resources:
+  points:
+    type: collection
+    title: Sample Points
+    description: Simple point data
+    keywords:
+      - sample
+      - points
+    provider:
+      type: feature
+      name: GeoJSON
+      data: /data/points.geojson
+      id_field: name
+    bbox: [-180,-90,180,90]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>MapLibre + Chart.js Example</title>
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <link href="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <style>
+    body { margin:0; padding:0; }
+    #map { position:absolute; top:0; bottom:50%; width:100%; }
+    #chart { position:absolute; bottom:0; height:50%; width:100%; }
+  </style>
+</head>
+<body>
+<div id="map"></div>
+<canvas id="chart"></canvas>
+<script src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://demotiles.maplibre.org/style.json',
+    center: [102.0, 0.5],
+    zoom: 3
+  });
+
+  fetch('http://localhost:5000/collections/points/items?f=json')
+    .then(r => r.json())
+    .then(data => {
+      map.on('load', () => {
+        map.addSource('points', {
+          type: 'geojson',
+          data: data
+        });
+        map.addLayer({
+          id: 'points-layer',
+          type: 'circle',
+          source: 'points',
+          paint: { 'circle-radius': 8, 'circle-color': '#007cbf' }
+        });
+      });
+
+      const labels = data.features.map(f => f.properties.name);
+      const chartData = data.features.map((f, i) => i + 1);
+      new Chart(document.getElementById('chart'), {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{ label: 'Sample', data: chartData }]
+        }
+      });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sample GeoJSON data
- configure pygeoapi to serve the sample data
- create a static web client using MapLibre and Chart.js
- orchestrate services with Docker Compose
- document setup in README

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684469814ba883318409823d75abeaf0