### PR TITLE
Fix pygeoapi startup by installing gunicorn

### DIFF
--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.13-slim
 
 # Install pygeoapi and GDAL bindings
 RUN apt-get update && apt-get install -y gdal-bin && \
-    pip install --no-cache-dir pygeoapi[all]
+    pip install --no-cache-dir pygeoapi[all] gunicorn
 
 # Copy config and data
 COPY pygeoapi-config.yml /etc/pygeoapi.yml


### PR DESCRIPTION
## Summary
- install gunicorn in the backend Dockerfile

## Testing
- `docker compose up --build -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844881644d4833191f55f7c030c9bd3