### PR TITLE
Fix missing flask-cors dependency

### DIFF
--- a/pygeoapi/installation.txt
+++ b/pygeoapi/installation.txt
@@ -8,4 +8,5 @@ jinja2>=3.0.0
 requests>=2.28.0
 jsonschema>=4.0.0
 flask>=2.0.0
-openapi-spec-validator>=0.5.0 
+openapi-spec-validator>=0.5.0
+flask-cors>=3.0.10


### PR DESCRIPTION
## Summary
- add `flask-cors` in `pygeoapi/installation.txt`

## Testing
- `make test` *(fails: virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b371df0083318f328c7f28558aab