### PR TITLE
Add hazard tiles config and docs

### DIFF
--- a/data/hazard/README.md
+++ b/data/hazard/README.md
@@ -1,0 +1,34 @@
+# Global Hazard Points Vector Tiles
+
+This directory contains instructions for generating the FlatGeobuf file and vector
+tiles used by the `hazard_points_fgb` collection in `pygeoapi`.
+
+The raw GeoJSON source `data/hazard_points_with_id.geojson` is quite large and
+should ideally be kept out of version control.
+
+## Generate the FlatGeobuf
+Convert the GeoJSON to FlatGeobuf for efficient serving:
+
+```bash
+ogr2ogr -f FlatGeobuf \
+  data/global-hazard-points.fgb \
+  data/hazard_points_with_id.geojson -nln GlobalHazardPoints
+```
+
+## Generate Vector Tiles
+Create Mapbox Vector Tiles with [tippecanoe](https://github.com/mapbox/tippecanoe):
+
+```bash
+tippecanoe \
+  -r1 -pk -pf \
+  --output-to-directory=data/tiles/hazard_points/ \
+  --force \
+  --maximum-zoom=15 \
+  --extend-zooms-if-still-dropping \
+  --no-tile-compression \
+  data/hazard_points_with_id.geojson
+```
+
+This produces a directory `data/tiles/hazard_points/` containing zoom levels `0`
+through `15` and a `metadata.json` file. Once generated, the tiles are served by
+pygeoapi using the `MVT-tippecanoe` provider defined in `pygeoapi/pygeoapi-config.yml`.

--- a/pygeoapi/pygeoapi-config.yml
+++ b/pygeoapi/pygeoapi-config.yml
@@ -96,17 +96,16 @@ resources:
               id_field: id
               options:
                 use_bbox: true  # Enable bbox filtering
-            # - type: tile
-            #   name: MVT
-            #   data: /data/tiles/hazard-points.mbtiles
-            #   options:
-            #     metadata_format: json
-            #     bounds: 
-            #       - -180.0
-            #       - -85.0
-            #       - 180.0
-            #       - 85.0
-            #     tile_format: mvt
+            - type: tile
+              name: MVT-tippecanoe
+              data: /data/tiles/hazard_points/
+              options:
+                zoom:
+                    min: 0
+                    max: 15
+              format:
+                    name: pbf
+                    mimetype: application/vnd.mapbox-vector-tile
 
     hyderabad:
         type: collection


### PR DESCRIPTION
## Summary
- generate hazard tiles via tippecanoe
- document hazard processing steps

## Testing
- `make check-system-deps`
- `make test` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845afd1d99083318d3f5b77caf5931a