### PR TITLE
Improve hazard layer popup

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -55,6 +55,12 @@
       .download-btn:hover {
         background-color: #1669bb;
       }
+      .properties-details summary {
+        cursor: pointer;
+        font-weight: bold;
+        margin-top: 5px;
+        margin-bottom: 5px;
+      }
       /* Loading indicator styles */
       #loading {
         position: absolute;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -60,6 +60,13 @@
 
       .download-btn:hover {
         background-color: #1669bb;
+      }
+
+      .properties-details summary {
+        cursor: pointer;
+        font-weight: bold;
+        margin-top: 5px;
+        margin-bottom: 5px;
       }
 
       /* Loading indicator styles */


### PR DESCRIPTION
## Summary
- put the chart and download button at the top of the hazard popup and move the properties into a collapsible section
- visualise the ARI values using a line chart with special markers for the 500‑year return period variants
- style the property collapsible element

## Testing
- `npm run format`
- `make test` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d422da248331a2e239af9534c055