### PR TITLE
Add GHCR workflow for frontend image

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -1,0 +1,34 @@
+name: Publish Frontend Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/global-tsunami-risk-map-frontend:latest
+            ghcr.io/${{ github.repository_owner }}/global-tsunami-risk-map-frontend:${{ github.sha }}
+

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ if you change the path or dataset name.
 This repository uses **Black**, **isort**, and **Ruff** for Python code. The frontend is formatted with **Prettier**. Recommended VS Code settings are provided in the `.vscode` folder.
 Run `pip install -r requirements-dev.txt` to install Python tooling. Frontend formatting tools can be installed by running `npm install` inside the `frontend` directory.
 Use `npm run format` to format frontend code.
+
+## CI/CD
+A GitHub Actions workflow builds and publishes the frontend Docker image whenever
+changes are pushed to the `frontend/` directory on the `main` branch. The image
+is pushed to the GitHub Container Registry under the tag
+`global-tsunami-risk-map-frontend`.


### PR DESCRIPTION
## Summary
- build/push frontend Docker image when frontend files change in `main`
- document the automatic image publishing process in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e916371a483318bafc69006b09fee