### PR TITLE
Fix frontend docker build version variable

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend-image.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -22,7 +24,8 @@ jobs:
           cd frontend
           npm ci
           npm version patch --no-git-tag-version
-          echo "VERSION=$(node -p 'require(\"./package.json\").version')" >> $GITHUB_ENV
+          VERSION=$(node -p 'require("./package.json").version')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           cd ..
       - name: Commit version bump
         run: |


### PR DESCRIPTION
## Summary
- ensure the frontend workflow path triggers when workflow file changes
- fix version variable assignment in workflow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e97d4264c833198fde427607b0a65