### PR TITLE
Fix frontend image build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:24-alpine as build
 WORKDIR /app
 COPY package.json package-lock.json ./
+COPY build.js ./
 RUN npm ci
 COPY src ./src
 RUN npm run build


### PR DESCRIPTION
## Summary
- copy `build.js` into Docker image so `npm run build` works during CI

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e9b422a4883319902579a61105c97